### PR TITLE
Change global variables to member attributes in NetworkAbstraction.js

### DIFF
--- a/lib/NetworkAbstraction.js
+++ b/lib/NetworkAbstraction.js
@@ -3,46 +3,44 @@
 var https = require("https");
 var url = require("url");
 var request = require("request");
-var hostname, apiVersion, apiKey = null;
 
-function NetworkAbstraction(givenKey, domain, preview) {
-    hostname = domain;
-    hostname += ".";
-    hostname += (!preview ? "okta.com" : "oktapreview.com");
-    apiVersion = "v1";
-    apiKey = givenKey;
+function NetworkAbstraction(apiKey, domain, preview) {
+    this._hostname = domain + '.' + (!preview ? 'okta.com' : 'oktapreview.com');
+    this._apiVersion = 'v1';
+    this._apiKey = apiKey;
 }
 
 NetworkAbstraction.prototype.get = function(what, query, followLink, callback) {
-    sendHttpReqNoBody("GET", constructURL(what), query, followLink, callback);
-}
+    this._sendHttpReqNoBody("GET", this._constructURL(what), query, followLink, callback);
+};
 
 NetworkAbstraction.prototype.post = function(where, what, query, callback) {
-    sendHttpReq("POST", constructURL(where), what, query, callback);
-}
+    this._sendHttpReq("POST", this._constructURL(where), what, query, callback);
+};
 
 NetworkAbstraction.prototype.put = function(where, what, query, callback) {
-    sendHttpReq("PUT", constructURL(where), what, query, callback);
-}
+    this._sendHttpReq("PUT", this._constructURL(where), what, query, callback);
+};
 
 NetworkAbstraction.prototype.delete = function(where, query, callback) {
-    sendHttpReqNoBody("DELETE", constructURL(where), query, callback);
-}
+    this._sendHttpReqNoBody("DELETE", this._constructURL(where), query, callback);
+};
 
 // POST and PUT requests are mostly identical.
-var sendHttpReq = function(method, where, what, query, callback) {
+NetworkAbstraction.prototype._sendHttpReq = function(method, where, what, query, callback) {
     var opts = {};
     if(what == undefined) opts.body = "";
     else opts.body = JSON.stringify(what);
     opts.headers = {};
     opts.headers['Content-Length'] = opts.body.length;
     opts.headers['Content-Type'] = "application/json";
-    opts.headers['Authorization'] = "SSWS " + apiKey;
+    opts.headers['Authorization'] = "SSWS " + this._apiKey;
     opts.method = method;
     opts.uri = url.parse(where);
     if(query != null) opts.qs = query;
-    request(opts, function(error, clientResp, resp) { handleResponse(error, false, clientResp, resp, callback) });
-}
+    var _this = this;
+    request(opts, function(error, clientResp, resp) { _this._handleResponse(error, false, clientResp, resp, callback) });
+};
 
 /*
 *   Old version did not have followLink flag, so to support backwards compatibility
@@ -52,7 +50,7 @@ var sendHttpReq = function(method, where, what, query, callback) {
 *
 *   *NOTE* all this is only relevant to Listing functions, nothing else uses filters
 */
-var sendHttpReqNoBody = function(method, where, query, followLink, callback) {
+NetworkAbstraction.prototype._sendHttpReqNoBody = function(method, where, query, followLink, callback) {
     var opts = {};
     //check if followLink is a function, if so do backwards compatable support
     //if not, proceed normally
@@ -65,13 +63,14 @@ var sendHttpReqNoBody = function(method, where, query, followLink, callback) {
     }
     if(query != null) opts.qs = query;
     opts.headers = {};
-    opts.headers['Authorization'] = "SSWS " + apiKey;
+    opts.headers['Authorization'] = "SSWS " + this._apiKey;
     opts.method = method;
     opts.uri = url.parse(where);
-    request(opts, function(error, clientResp, resp) { handleResponse(error, followLink, clientResp, resp, callback) });
-}
+    var _this = this;
+    request(opts, function(error, clientResp, resp) { _this._handleResponse(error, followLink, clientResp, resp, callback) });
+};
 
-function handleResponse(error, followLink, clientResp, resp, callback) {
+NetworkAbstraction.prototype._handleResponse = function(error, followLink, clientResp, resp, callback) {
     //console.log(require('util').inspect(clientResp, {depth:null}));
     if(callback == undefined) return;
     if(error) {
@@ -92,8 +91,7 @@ function handleResponse(error, followLink, clientResp, resp, callback) {
                 outObj.paged = true;
                 outObj.pageEnd = true;
                 var links = clientResp.headers.link.split(",");
-                var hasNext = false;
-                for(i in links) {
+                for(var i in links) {
                     var link = links[i];
                     var bits = link.split(";");
                     if (bits[1] == " rel=\"next\"") {
@@ -104,8 +102,9 @@ function handleResponse(error, followLink, clientResp, resp, callback) {
                             outObj.next = finalLink;
                             break;
                         }
-                        else
-                            sendHttpReqNoBody("GET", finalLink, null, callback);
+                        else {
+                            this._sendHttpReqNoBody("GET", finalLink, null, callback);
+                        }
                     }
                 }
             }
@@ -123,10 +122,10 @@ function handleResponse(error, followLink, clientResp, resp, callback) {
             callback({success: false, paged: false, error: "Received HTTP Status code: " + clientResp.statusCode, resp: resp})
         }
     }
-}
+};
 
-function constructURL(what) {
-    return "https://" + hostname + "/api/" + apiVersion + "/" + what;
-}
+NetworkAbstraction.prototype._constructURL = function (what) {
+    return "https://" + this._hostname + "/api/" + this._apiVersion + "/" + what;
+};
 
 module.exports = NetworkAbstraction;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
       "url": "http://github.com/snowulf/oktajs/issues"
   },
   "main": "index.js",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "engines": "node >= 0.10.40",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
As mentioned in #3 , I've moved the `hostname`, `apiVersion` and `apiKey` variables to attributes of the `NetworkAbstraction` class. This also affected the `sendHttpReq`, `sendHttpReqNoBody`, `handleResponse` and `constructURL` functions as they needed to become part of the prototype. 

I've used the underscore notation as part of the standard to define "private" functions and variables.

It seems to be passing all the relevant tests and has also solved my issue. Be sure to let me know if you see any issues with it! 😄 